### PR TITLE
enable epel-next

### DIFF
--- a/kickstarts/8/base-repo.ks
+++ b/kickstarts/8/base-repo.ks
@@ -2,4 +2,5 @@ repo --name=BaseOS --mirrorlist=http://mirrorlist.centos.org/?release=$releaseve
 repo --name=AppStream --mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=AppStream&infra=$infra
 repo --name=PowerTools --mirrorlist=http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=PowerTools&infra=$infra
 repo --name=epel --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=epel-$releasever&arch=$basearch
+repo --name=epel-next --mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-next-$releasever&arch=$basearch
 url --mirrorlist="http://mirrorlist.centos.org/?release=$releasever-stream&arch=$basearch&repo=BaseOS&infra=$infra"

--- a/kickstarts/8/base.ks
+++ b/kickstarts/8/base.ks
@@ -38,6 +38,7 @@ psmisc
 centos-stream-release
 centos-stream-repos
 epel-release
+epel-next-release
 
 # Explicitly specified here:
 # <notting> walters: because otherwise dependency loops cause yum issues.

--- a/kickstarts/8/kde-packages.ks
+++ b/kickstarts/8/kde-packages.ks
@@ -34,9 +34,9 @@ pam-kwallet
 phonon-qt5-backend-gstreamer
 plasma-breeze
 plasma-desktop
-# plasma-discover
-# plasma-discover-flatpak
-# plasma-discover-notifier
+plasma-discover
+plasma-discover-flatpak
+plasma-discover-notifier
 plasma-milou
 plasma-nm-l2tp
 plasma-nm-openvpn
@@ -49,8 +49,8 @@ sddm
 sddm-breeze
 sddm-kcm
 spectacle
-# svgpart
-# sweeper
+svgpart
+sweeper
 upower
 xdg-desktop-portal-kde
 


### PR DESCRIPTION
During install, enable epel-next repo
During install, install epel-next-release
During install, install those packages that are now in epel-next repo.

Signed-off-by: Troy Dawson <tdawson@redhat.com>
